### PR TITLE
Update jquery.bxslider-rahisified.js

### DIFF
--- a/jquery.bxslider-rahisified.js
+++ b/jquery.bxslider-rahisified.js
@@ -1498,7 +1498,7 @@
 		 * auto reload functionality
 		 */
     $(window).resize(function() {
-      if(slider.settings.autoReload) {
+      if(slider.settings.autoReload && $(window).width() != windowWidth) {
         el.reloadSlider();
       }
     });


### PR DESCRIPTION
Prevent reload when nothing is actually resized. Seem to be known behavior on Ios, see: http://stackoverflow.com/questions/8898412/iphone-ipad-triggering-unexpected-resize-events